### PR TITLE
Feature - use real redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,7 @@ $ npm run test:acceptance
 
 #### Setup
 
-SO Acceptance comes with session mocking so you are able to test steps independently of one another. The easiest way to implement this is to use [hof-bootstrap](https://github.com/UKHomeOffice/hof-bootstrap/) and pass the mockSession store in config:
-
-app.js
-```js
-var bootstrap = require('hof-bootstrap');
-var sessionStore = require('so-acceptance/mock-session');
-
-module.exports = bootstrap({
-  sessionStore: process.env.NODE_ENV === 'ci' ? sessionStore : null,
-  ... your config
-});
-```
+SO Acceptance comes with session mocking so you are able to test steps independently of one another. This assumes you are using  [hof-bootstrap](https://github.com/UKHomeOffice/hof-bootstrap/) and redis for session storage.
 
 #### API
 
@@ -81,7 +70,7 @@ The following methods have been added to `I`:
 * `visitPage(page, [journey], [prereqs])`: visits `'/'`, then page, prepending journey if present, and setting prereq steps. Page and Prereqs are expected to be [PageObjects](https://github.com/Codeception/CodeceptJS/blob/master/docs/pageobjects.md) with a `url` property.
 * `seeErrors(errors)`: accepts either an array of keys or a single key, and checks for validation errors related to the element.
 * `seeElements(elements)`: accepts either an array of selectors or a single selector and checks all elements are present on the page.
-* `refreshPage()`: refreshes the page.
+* `refreshPage()`: refreshes the page - async, should be called within a generator.
 
 ### Customisation
 

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -28,8 +28,6 @@ const baseConfig = {
       require: './helpers/navigation'
     }
   },
-  bootstrap: './setup.js',
-  teardown: './teardown.js',
   mocha: {},
   name: 'hof-acceptance',
   include: {

--- a/helpers/navigation.js
+++ b/helpers/navigation.js
@@ -4,10 +4,6 @@ const Helper = require('codeceptjs/lib/helper');
 
 module.exports = class Navigation extends Helper {
   refreshPage() {
-    return new Promise((resolve, reject) => {
-      this.helpers.WebDriverIO.browser.refresh()
-        .then(resolve)
-        .catch(reject);
-    });
+    return this.helpers.WebDriverIO.browser.refresh();
   }
 };

--- a/helpers/navigation.js
+++ b/helpers/navigation.js
@@ -4,6 +4,10 @@ const Helper = require('codeceptjs/lib/helper');
 
 module.exports = class Navigation extends Helper {
   refreshPage() {
-    this.helpers.WebDriverIO.browser.refresh();
+    return new Promise((resolve, reject) => {
+      this.helpers.WebDriverIO.browser.refresh()
+        .then(resolve)
+        .catch(reject);
+    });
   }
 };

--- a/mock-session.js
+++ b/mock-session.js
@@ -1,5 +1,0 @@
-'use strict';
-
-const MemoryStore = require('express-session').MemoryStore;
-
-module.exports = new MemoryStore();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
   "author": "UKHomeOffice",
   "dependencies": {
     "codeceptjs": "^0.4.3",
+    "connect-redis": "^3.1.0",
+    "cookie-parser": "^1.4.3",
     "express-session": "^1.14.0",
+    "hof-bootstrap": "^3.2.0",
     "lodash": "^4.14.2",
     "webdriverio": "^4.2.5"
   },

--- a/setup.js
+++ b/setup.js
@@ -1,6 +1,0 @@
-'use strict';
-
-// eslint-disable-next-line no-console
-console.info('HOF-Acceptance starting App');
-
-require('../../app');

--- a/steps.js
+++ b/steps.js
@@ -33,6 +33,14 @@ module.exports = () => {
       this.seeInCurrentUrl(url);
     },
 
+    seeHint(field) {
+      this.seeElement(`${field}-hint`);
+    },
+
+    dontSeeHint(field) {
+      this.dontSeeElement(`${field}-hint`);
+    },
+
     seeErrors(fields) {
       if (!Array.isArray(fields)) {
         fields = [fields];

--- a/teardown.js
+++ b/teardown.js
@@ -1,8 +1,0 @@
-'use strict';
-
-// eslint-disable-next-line no-console
-console.info('HOF-Acceptance stopping App');
-
-const app = require('../../app');
-
-app.then(bootstrap => bootstrap.stop());

--- a/test/unit/helpers/navigation.js
+++ b/test/unit/helpers/navigation.js
@@ -4,7 +4,7 @@ const proxyquire = require('proxyquire');
 
 const mockWebDriverHelper = {
   browser: {
-    refresh: sinon.stub()
+    refresh: sinon.stub().returns(new Promise(resolve => resolve()))
   }
 };
 
@@ -35,8 +35,14 @@ describe('Navigation Helper', () => {
     navigationHelper.should.have.property('refreshPage').and.be.a('function');
   });
 
-  it('should call WebDriverIO.browser.refresh', () => {
-    navigationHelper.refreshPage();
-    mockWebDriverHelper.browser.refresh.should.have.been.calledOnce;
+  it('should return a promise', () => {
+    navigationHelper.refreshPage().should.be.a('promise');
+  });
+
+  it('should call WebDriverIO.browser.refresh', done => {
+    navigationHelper.refreshPage().then(() => {
+      mockWebDriverHelper.browser.refresh.should.have.been.calledTwice;
+      done();
+    });
   });
 });

--- a/test/unit/steps.js
+++ b/test/unit/steps.js
@@ -30,6 +30,14 @@ describe('Actor functionality extensions', () => {
       actor.should.have.property('visitPage');
     });
 
+    it('exposes a seeHint method', () => {
+      actor.should.have.property('seeHint');
+    });
+
+    it('exposes a dontSeeHint method', () => {
+      actor.should.have.property('dontSeeHint');
+    });
+
     it('exposes a seeErrors function', () => {
       actor.should.have.property('seeErrors');
     });
@@ -45,6 +53,7 @@ describe('Actor functionality extensions', () => {
         actor.seeInCurrentUrl = sinon.stub();
         actor.setSessionSteps = sinon.stub();
         actor.seeElement = sinon.stub();
+        actor.dontSeeElement = sinon.stub();
       });
 
       describe('submitForm', () => {
@@ -107,6 +116,64 @@ describe('Actor functionality extensions', () => {
                 `/${prereqs[0].url}`
               ]);
           });
+        });
+      });
+
+      describe('seeHint', () => {
+        it('calls seeElement with -hint appended to field', () => {
+          actor.seeHint('field');
+          actor.seeElement.should.have.been.calledOnce
+            .and.calledWithExactly('field-hint');
+        });
+      });
+
+      describe('dontSeeHint', () => {
+        it('calls dontSeeElement with -hint appended to field', () => {
+          actor.dontSeeHint('field');
+          actor.dontSeeElement.should.have.been.calledOnce
+            .and.calledWithExactly('field-hint');
+        });
+      });
+
+      describe('seeErrors', () => {
+        it('calls seeElement for each element passed', () => {
+          actor.seeErrors(['something', 'something-else']);
+          actor.seeElement.should.have.been.calledTwice;
+        });
+
+        it('accepts a single value', () => {
+          actor.seeErrors('something');
+          actor.seeElement.should.have.been.calledOnce;
+        });
+
+        it('calls seeElement with -group.validation-error appended', () => {
+          actor.seeErrors('something');
+          actor.seeElement.should.have.been.calledOnce
+            .and.calledWithExactly('something-group.validation-error');
+        });
+
+        it('doesn\'t append -group if the element ends with -group', () => {
+          actor.seeErrors('something-group');
+          actor.seeElement.should.have.been.calledOnce
+            .and.calledWithExactly('something-group.validation-error');
+        });
+      });
+
+      describe('seeElements', () => {
+        it('calls seeElement for each element passed', () => {
+          actor.seeElements(['something', 'something-else']);
+          actor.seeElement.should.have.been.calledTwice;
+        });
+
+        it('accepts a single value', () => {
+          actor.seeElements('something');
+          actor.seeElement.should.have.been.calledOnce;
+        });
+
+        it('calls seeElement with the element passed', () => {
+          actor.seeElements('something');
+          actor.seeElement.should.have.been.calledOnce
+            .and.calledWithExactly('something');
         });
       });
     });


### PR DESCRIPTION
MemoryStore can only be used if the acceptance tests are run alongside the application in the same container. In order to test in isolation Redis needs to be used for session storage.

* Removed setup and teardown options - app is now run in a separate container
* Amended SessionHelper to get sessionId from cookie - decode with cookie-parser
* Updated tests