### PR TITLE
Feature - auto set steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "connect-redis": "^3.1.0",
     "cookie-parser": "^1.4.3",
     "express-session": "^1.14.0",
+    "hmpo-form-wizard": "^5.1.1",
     "hof-bootstrap": "^3.2.0",
     "lodash": "^4.14.2",
     "webdriverio": "^4.2.5"

--- a/steps.js
+++ b/steps.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const actor = require('codeceptjs/lib/actor');
+const getRouteSteps = require('hmpo-form-wizard/lib/util/helpers').getRouteSteps;
 
 module.exports = () => {
   return actor({
@@ -13,22 +14,17 @@ module.exports = () => {
       this.click(this.selectors.submit);
     },
 
-    visitPage(page, journey, prereqs) {
-      let start = '';
-      if (journey) {
-        start = `${journey}/`;
-      }
-      const url = `/${start}${page.url}`;
+    visitPage(page, options) {
+      const base = options.baseUrl || '';
+      const url = `${base}/${page.url}`;
+      const steps = getRouteSteps(`/${page.url}`, options.steps);
 
       this.amOnPage('/');
 
-      if (prereqs) {
-        if (!Array.isArray(prereqs)) {
-          prereqs = [prereqs];
-        }
-        prereqs = prereqs.map(prereq => `/${prereq.url}`);
-        this.setSessionSteps(journey, prereqs);
+      if (steps.length) {
+        this.setSessionSteps(options.name, steps);
       }
+
       this.amOnPage(url);
       this.seeInCurrentUrl(url);
     },


### PR DESCRIPTION
Prereqs should be automatically set when testing, rather than having to explicitly set the before each test.

* amended visit page helper to accept page and steps config
* added hmpo-form-wizard as dep
* use hmpo-form-wizard getRouteSteps helper to get prereqs
* preset prereqs if present