### PR TITLE
Export a binary from so-acceptance module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,11 @@ $ npm install so-acceptance --save-dev
 #### Setup
 
 For quickstart usage you can simply npm install the library and add the following script to your package.json.
-> note - this assumes you are using NPM@3. If you are using a previous version of NPM you will need to point to the relative path of the codeceptjs exectuable. This will be located at ./node_modules/so-acceptance/.bin/codeceptjs
 
 package.json
 ```json
 "scripts": {
-  "test:acceptance": "codeceptjs run ./node_modules/so-acceptance --steps"
+  "test:acceptance": "so-acceptance --steps"
 }
 ```
 

--- a/bin/so-acceptance
+++ b/bin/so-acceptance
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+const cp = require('child_process');
+const witch = require('witch');
+const path = require('path');
+
+const codecept = witch('codeceptjs');
+
+const config = path.resolve(__dirname, '../');
+
+const args = ['run', config].concat(process.argv.slice(2));
+
+cp.spawn(codecept, args, {stdio: 'inherit', cwd: process.cwd()});

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -6,14 +6,16 @@ const _ = require('lodash');
 let localConfig = {};
 
 try {
-  localConfig = require(path.resolve(__dirname, '../../codecept.conf'));
+  localConfig = require(path.resolve(process.cwd(), './codecept.conf'));
 } catch (err) {
   // eslint-disable-next-line no-console
   console.info('Local config not found, using defaults');
 }
 
+const tests = path.relative(__dirname, path.resolve(process.cwd(), './apps/**/features/**/*.js'));
+
 const baseConfig = {
-  tests: '../../apps/**/features/**/*.js',
+  tests: tests,
   timeout: 10000,
   output: './output',
   helpers: {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "NodeJS acceptance testing for HOF Applications",
   "license": "GPL-2.0",
   "main": "codecept.conf.js",
+  "bin": {
+    "so-acceptance": "bin/so-acceptance"
+  },
   "scripts": {
     "test": "npm run style && npm run lint && npm run coverage",
     "coverage": "NODE_ENV=test istanbul cover _mocha",
@@ -29,10 +32,11 @@
     "connect-redis": "^3.1.0",
     "cookie-parser": "^1.4.3",
     "express-session": "^1.14.0",
-    "hof-form-wizard": "^1.0.2",
     "hof-bootstrap": "^6.0.0",
+    "hof-form-wizard": "^1.0.2",
     "lodash": "^4.14.2",
-    "webdriverio": "^4.2.5"
+    "webdriverio": "^4.2.5",
+    "witch": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This helps to clean up the command used for executing a test run in dependent modules. It also decouples from codeceptjs since this is no longer exposed to any implementations.

This has the additional benefit that since it no longer depends on a particular relative install location for codeceptjs, the restriction for npm versions can be lifted.