### PR TITLE
Pass config file location as `--config` flag to codecept

### DIFF
--- a/bin/so-acceptance
+++ b/bin/so-acceptance
@@ -6,8 +6,8 @@ const path = require('path');
 
 const codecept = witch('codeceptjs');
 
-const config = path.resolve(__dirname, '../');
+const config = path.resolve(__dirname, '../codecept.conf.js');
 
-const args = ['run', config].concat(process.argv.slice(2));
+const args = ['run', '--config', config].concat(process.argv.slice(2));
 
 cp.spawn(codecept, args, {stdio: 'inherit', cwd: process.cwd()});

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -12,10 +12,8 @@ try {
   console.info('Local config not found, using defaults');
 }
 
-const tests = path.relative(__dirname, path.resolve(process.cwd(), './apps/**/features/**/*.js'));
-
 const baseConfig = {
-  tests: tests,
+  tests: './apps/**/features/**/*.js',
   timeout: 10000,
   output: './output',
   helpers: {
@@ -24,16 +22,16 @@ const baseConfig = {
       browser: 'phantomjs'
     },
     Session: {
-      require: './helpers/session'
+      require: path.resolve(__dirname, './helpers/session')
     },
     Navigation: {
-      require: './helpers/navigation'
+      require: path.resolve(__dirname, './helpers/navigation')
     }
   },
   mocha: {},
   name: 'hof-acceptance',
   include: {
-    I: './steps.js'
+    I: path.resolve(__dirname, './steps.js')
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "author": "UKHomeOffice",
   "dependencies": {
-    "codeceptjs": "0.4.5",
+    "codeceptjs": "^0.4.13",
     "connect-redis": "^3.1.0",
     "cookie-parser": "^1.4.3",
     "express-session": "^1.14.0",


### PR DESCRIPTION
This means that the root directory for the test run defaults to the current working directory - i.e. the project directory - instead of the `so-acceptance` install directory. This makes it easier to pass custom, per-project config because the paths in project config are relative to their own directory and not `so-acceptance`.