### PR TITLE
Re-add webdriverio

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "hof-bootstrap": "^10.0.0",
     "hof-form-wizard": "^3.2.0",
     "lodash": "^4.14.2",
+    "webdriverio": "^4.6.2",
     "witch": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is required by codecept as a plugin, so while we don't use it anywhere directly, it needs to be installed.