### PR TITLE
Add test to ensure webdriverio is always present

### DIFF
--- a/test/unit/module.js
+++ b/test/unit/module.js
@@ -1,0 +1,12 @@
+'use strict';
+
+describe('module', () => {
+
+  it('has webdriverio as a dependency', () => {
+    // codecept needs to have webdriverio installed as a dependency to run
+    // ensure it is declared here so it is not accidentally removed
+    const pkg = require('../../package.json');
+    pkg.dependencies.should.have.a.property('webdriverio');
+  });
+
+});


### PR DESCRIPTION
Since webdriverio is not actually required anywhere in this project, but is a defacto peer dependency of codecept, we need to ensure it is not inadvertently removed by someone auditing this project's dependencies.