### PR TITLE
Ensure so-acceptance binary exists with appropriate exit code

### DIFF
--- a/bin/so-acceptance
+++ b/bin/so-acceptance
@@ -10,4 +10,8 @@ const config = path.resolve(__dirname, '../codecept.conf.js');
 
 const args = ['run', '--config', config].concat(process.argv.slice(2));
 
-cp.spawn(codecept, args, {stdio: 'inherit', cwd: process.cwd()});
+const runner = cp.spawn(codecept, args, {stdio: 'inherit', cwd: process.cwd()});
+
+runner.once('exit', (code) => {
+  process.exit(code);
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "author": "UKHomeOffice",
   "dependencies": {
-    "codeceptjs": "^0.4.16",
+    "codeceptjs": "^0.5.0",
     "connect-redis": "^3.1.0",
     "cookie-parser": "^1.4.3",
     "express-session": "^1.14.0",


### PR DESCRIPTION
There was a bug in old version of codecept which is now fixed.