### PR TITLE
Remove dependency on hof-bootstrap

### DIFF
--- a/helpers/encryption.js
+++ b/helpers/encryption.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const crypto = require('crypto');
+const algorithm = 'aes-256-ctr';
+
+module.exports = (password) => ({
+
+  encrypt: (text) => {
+    const cipher = crypto.createCipher(algorithm, password);
+    let crypted = cipher.update(text, 'utf8', 'hex');
+    crypted += cipher.final('hex');
+    return crypted;
+  },
+
+  decrypt: (text) => {
+    const decipher = crypto.createDecipher(algorithm, password);
+    let dec = decipher.update(text, 'hex', 'utf8');
+    dec += decipher.final('utf8');
+    return dec;
+  }
+
+});

--- a/helpers/session.js
+++ b/helpers/session.js
@@ -9,7 +9,7 @@ const SESSION_KEY_PREFIX = 'hof-wizard';
 const SESSION_KEY_COOKIE_NAME = 'hod.sid';
 const SECRET = 'changethis';
 
-const encryption = require('hof-bootstrap/lib/encryption')(SECRET);
+const encryption = require('./encryption')(SECRET);
 
 module.exports = class Session extends Helper {
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "connect-redis": "^3.1.0",
     "cookie-parser": "^1.4.3",
     "express-session": "^1.14.0",
-    "hof-bootstrap": "^10.0.0",
     "hof-form-wizard": "^3.2.0",
     "hof-util-autofill": "^1.1.0",
     "lodash": "^4.14.2",


### PR DESCRIPTION
Loading all of hof-bootstrap into the dependency tree to get access to one small module was kinda nasty - especially when the major versions weren't in sync. A *good* way of solving this would be to abstract the module into a standalone npm thing, but that feels like overkill for something which is highly unlikely to change.