### PR TITLE
Update codeceptjs to latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
 node_js:
   - "6"
-  - "4"
-
-before_install:
-  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
+  - "8"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "author": "UKHomeOffice",
   "dependencies": {
-    "codeceptjs": "^0.5.0",
+    "codeceptjs": "^0.6.3",
     "connect-redis": "^3.1.0",
     "cookie-parser": "^1.4.3",
     "express-session": "^1.14.0",


### PR DESCRIPTION
Codecept before 0.6.0 would exit with a zero exit code if there were errors thrown in test setup. This is bad.