### PR TITLE
Fix webdriverio version to 4.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "hof-form-wizard": "^3.2.0",
     "hof-util-autofill": "^1.1.3",
     "lodash": "^4.17.4",
-    "webdriverio": "^4.6.2",
+    "webdriverio": "4.8.0",
     "witch": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Until a fix for https://github.com/webdriverio/webdriverio/issues/2422 is in place then we'll need to stick with 4.8.0 or our selectors will fail.